### PR TITLE
Fix token handling in pairings endpoint

### DIFF
--- a/supabase_api.py
+++ b/supabase_api.py
@@ -133,8 +133,16 @@ def get_pairings():
     if not supabase:
         return jsonify({"error": "Database connection not configured"}), 500
 
+    auth_header = request.headers.get('Authorization')
+    if not auth_header:
+        return jsonify({"error": "Authorization header missing"}), 401
+
+    parts = auth_header.split()
+    if len(parts) != 2 or parts[0].lower() != 'bearer' or not parts[1].strip():
+        return jsonify({"error": "Malformed authorization header"}), 400
+
     # In a real app, user_id would come from the validated JWT
-    user_id = request.headers.get('Authorization').split(' ')[1] # Placeholder
+    user_id = parts[1]
 
     try:
         res = supabase.table('pairings').select('*').eq('user_id', user_id).order('start_date', desc=True).execute()

--- a/test_pairings_auth.py
+++ b/test_pairings_auth.py
@@ -1,0 +1,25 @@
+import pytest
+from flask import Flask
+import supabase_api
+
+class DummySupabase:
+    pass
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    supabase_api.supabase = DummySupabase()
+    app.register_blueprint(supabase_api.supabase_api_blueprint)
+    with app.test_client() as client:
+        yield client
+
+def test_missing_authorization_header(client):
+    resp = client.get('/pairings')
+    assert resp.status_code == 401
+    assert resp.get_json()['error'] == 'Authorization header missing'
+
+def test_malformed_authorization_header(client):
+    resp = client.get('/pairings', headers={'Authorization': 'Bearer'})
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == 'Malformed authorization header'


### PR DESCRIPTION
## Summary
- validate Authorization header in `get_pairings`
- add tests for missing and malformed headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687acb0b83388329aef4575e214c56a9