### PR TITLE
Fix env placeholder mismatch

### DIFF
--- a/build.py
+++ b/build.py
@@ -71,9 +71,11 @@ def inject_env_variables():
     try:
         with open(config_js_path, 'r') as f:
             content = f.read()
-        
-        content = content.replace('YOUR_SUPABASE_URL_FROM_ENV', supabase_url)
-        content = content.replace('YOUR_SUPABASE_ANON_KEY_FROM_ENV', supabase_anon_key)
+
+        # Replace placeholder tokens in the config file with actual values
+        # from the environment.
+        content = content.replace('{{SUPABASE_URL}}', supabase_url)
+        content = content.replace('{{SUPABASE_ANON_KEY}}', supabase_anon_key)
         
         with open(config_js_path, 'w') as f:
             f.write(content)


### PR DESCRIPTION
## Summary
- update build script to match placeholder tokens in `supabase-config.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests' / 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_687acb06a1d88329a82b0b0221198fa4