### PR TITLE
Fix index template reference

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ app.register_blueprint(supabase_api_blueprint, url_prefix='/api')
 def index():
     """Serve the main application page."""
     # This now serves the redesigned frontend
-    return render_template('index_redesign.html')
+    return render_template('index.html')
 
 @app.route('/static/<path:path>')
 def send_static(path):


### PR DESCRIPTION
## Summary
- point root route at the existing `index.html` template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687acb01c8188329a09f95351fee39e6