### PR TITLE
Fix wrong scraper import

### DIFF
--- a/supabase_api.py
+++ b/supabase_api.py
@@ -7,7 +7,10 @@ from flask import Blueprint, request, jsonify
 import logging
 from supabase_client import SupabaseClient
 from enhanced_parser import EnhancedParser
-from enhanced_scraper import EnhancedScraper
+# The enhanced_scraper module exposes the CcsScraper class which provides
+# all scraping capabilities. The previous import used a non-existent
+# `EnhancedScraper` name which would raise an ImportError at runtime.
+from enhanced_scraper import CcsScraper
 from google_client import get_google_auth_url, get_credentials_from_code, create_google_calendar_service, add_events_to_calendar
 
 # Configure logging


### PR DESCRIPTION
## Summary
- fix invalid import of non-existent `EnhancedScraper` and reference the actual `CcsScraper`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', 'selenium')*
- `pip install -q -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ab487abb08329bbf599e755732173